### PR TITLE
Fix html

### DIFF
--- a/html/html.html
+++ b/html/html.html
@@ -783,7 +783,7 @@
                                 正しい構成・セマンティックを意識しながら下記のサイトの画像通り作る。
                             </li>
                             <li>
-                                <a target="_target" href="https://developer.mozilla.org/ko/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter">
+                                <a target="_blank" href="https://developer.mozilla.org/ko/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter">
                                     Marking up a letter.
                                 </a>
                             </li>

--- a/html/html.html
+++ b/html/html.html
@@ -795,7 +795,7 @@
                 <h3>例題</h3>
                 <section>
                     <h4>元データ</h4>
-                    <cite href="https://github.com/mdn/learning-area/blob/main/html/introduction-to-html/marking-up-a-letter-start/letter-text.txt">
+                    <cite>
                         <a target="_blank" href="https://github.com/mdn/learning-area/blob/main/html/introduction-to-html/marking-up-a-letter-start/letter-text.txt">
                             Github - chrisdavidmills - mdn/learning-area
                         </a>


### PR DESCRIPTION
対応内容
html/html.html-Marking up a letter定義部分-aタグのtarget属性の値を_targetから_blankに修正(line:786)
html/html.html-Marking up a letter例題部分-citeタグはhref属性が入らないタグだったため、citeタグのhref属性を削除(line:799)

確認事項
html/html.html 786行のaタグの属性が_targetから_blankに変更されたこと
html/html.html 798行のciteタグの属性hreftが削除されていること

申し送り
ない