### PR TITLE
Fix marking up a letter

### DIFF
--- a/html/marking-up-a-letter.html
+++ b/html/marking-up-a-letter.html
@@ -34,103 +34,101 @@
     </style>
 </head>
 <body>
-    <article>
-        <header>
-            <article class="sender-column">
-                <address>
-                    <strong>Dr. Eleanor Gaye</strong><br>
-                    Awesome Science faculty<br>
-                    University of Awesome<br>
-                    Bobtown, CA 99999,<br>
-                    USA<br>
-                    <strong>Tel</strong>: 123-456-7890<br>
-                    <strong>Email</strong>: no_reply@example.com<br><br>
-                    <time datetime="2016-01-20">20 January 2016</time>
-                </address>
-            </article>
-            <article>
-                <address>
-                    <strong>Miss Eileen Dover</strong><br>
-                    4321 Cliff Top Edge<br>
-                    Dover, CT9 XXX<br>
-                    UK<br>
-                </address>
-            </article>
-        </header>
-        <main>
-            <article>
-                <h1>Re: Eileen Dover university application</h1>
-                <section>
-                    <p>Dear Eileen,</p>
-                    <p>Thank you for your recent application to join us at the University of Awesome's science faculty to study as part of your <abbr title="Doctor of Philosophy">PhD</abbr> next year. I will answer your questions one by one, in the following sections.</p>
-                </section>
-                <section>
-                    <h2>Starting dates</h2>
-                    <p>We are happy to accommodate you starting your study with us at any time, however it would suit us better if you could start at the beginning of a semester; the start dates for each one are as follows:</p>
-                    <ul>
-                        <li>
-                            First semester: <time datetime="2016-09-09">9 September 2016</time>
-                        </li>
-                        <li>
-                            Second semester: <time datetime="2017-01-15">15 January 2017</time>
-                        </li>
-                        <li>
-                            Third semester: <time datetime="2017-05-02">2 May 2017</time>
-                        </li>
-                    </ul>
-                    <p>Please let me know if this is ok, and if so which start date you would prefer.</p>
-                    <p>You can find more information about <a target="_blank" href="http://example.com">important university dates</a> on our website.</p>
-                </section>
-                <section>
-                    <h2>Subject of study</h2>
-                    <p>At the Awesome Science Faculty, we have a pretty open-minded research facility — as long as the subjects fall somewhere in the realm of science and technology. You seem like an intelligent, dedicated researcher, and just the kind of person we'd like to have on our team. Saying that, of the ideas you submitted we were most intrigued by are as follows, in order of priority:</p>
-                    <ol>
-                        <li>
-                            Turning H<sub>2</sub>O into wine, and the health benefits of Resveratrol (C<sub>14</sub>H<sub>12</sub>O<sub>3</sub>.)
-                        </li>
-                        <li>
-                            Measuring the effect on performance of funk bassplayers at temperatures exceeding 30°C (86°F), when the audience size exponentially increases (effect of 3 × 10<sup>3</sup> increasing to 3 × 10<sup>4</sup>.)
-                        </li>
-                        <li>
-                            <abbr title="Hyper Text Markup Language">HTML</abbr> and <abbr title="Cascading Style Sheets">CSS</abbr> constructs for representing musical scores.
-                        </li>
-                    </ol>
-                    <p>So please can you provide more information on each of these subjects, including how long you'd expect the research to take, required staff and other resources, and anything else you think we'd need to know? Thanks.</p>
-                </section>
-                <section>
-                    <h2>Exotic dance moves</h2>
-                    <p>Yes, you are right! As part of my post-doctorate work, I <em>did</em> study exotic tribal dances. To answer your question, my favourite dances are as follows, with definitions:</p>
-                    <dl>
-                        <dt>
-                            Polynesian chicken dance
-                        </dt>
-                        <dd>
-                            A little known but <em>very</em> influential dance dating back as far as 300<abbr title="Before Christ">BC</abbr>, a whole village would dance around in a circle like chickens, to encourage their livestock to be "fruitful".
-                        </dd>
-                        <dt>
-                            Icelandic brownian shuffle
-                        </dt>
-                        <dd>
-                            Before the Icelanders developed fire as a means of getting warm, they used to practice this dance, which involved huddling close together in a circle on the floor, and shuffling their bodies around in imperceptibly tiny, very rapid movements. One of my fellow students used to say that he thought this dance inspired modern styles such as Twerking.
-                        </dd>
-                        <dt>
-                            Arctic robot dance
-                        </dt>
-                        <dd>
-                            An interesting example of historic misinformation, English explorers in the 1960s believed to have discovered a new dance style characterized by "robotic", stilted movements, being practiced by inhabitants of Northern Alaska and Canada. Later on however it was discovered that they were just moving like this because they were really cold.
-                        </dd>
-                    </dl>
-                </section>
-                <section>
-                    <p>For more of my research, see my exotic dance research page.</p>
-                    <p>Yours sincerely,</p>
-                    <p>Dr Eleanor Gaye</p>
-                    <p>University of Awesome motto: <q cite="The memoirs of Bill S Preston, Esq">Be awesome to each other.</q><cite>--The memoirs of Bill S Preston, Esq</cite></p>
-                </section>
-            </article>
-        </main>
-        <footer>
-        </footer>
-    </article>
+    <header>
+        <article class="sender-column">
+            <address>
+                <strong>Dr. Eleanor Gaye</strong><br>
+                Awesome Science faculty<br>
+                University of Awesome<br>
+                Bobtown, CA 99999,<br>
+                USA<br>
+                <strong>Tel</strong>: 123-456-7890<br>
+                <strong>Email</strong>: no_reply@example.com<br><br>
+                <time datetime="2016-01-20">20 January 2016</time>
+            </address>
+        </article>
+        <article>
+            <address>
+                <strong>Miss Eileen Dover</strong><br>
+                4321 Cliff Top Edge<br>
+                Dover, CT9 XXX<br>
+                UK<br>
+            </address>
+        </article>
+    </header>
+    <main>
+        <article>
+            <h1>Re: Eileen Dover university application</h1>
+            <section>
+                <p>Dear Eileen,</p>
+                <p>Thank you for your recent application to join us at the University of Awesome's science faculty to study as part of your <abbr title="Doctor of Philosophy">PhD</abbr> next year. I will answer your questions one by one, in the following sections.</p>
+            </section>
+            <section>
+                <h2>Starting dates</h2>
+                <p>We are happy to accommodate you starting your study with us at any time, however it would suit us better if you could start at the beginning of a semester; the start dates for each one are as follows:</p>
+                <ul>
+                    <li>
+                        First semester: <time datetime="2016-09-09">9 September 2016</time>
+                    </li>
+                    <li>
+                        Second semester: <time datetime="2017-01-15">15 January 2017</time>
+                    </li>
+                    <li>
+                        Third semester: <time datetime="2017-05-02">2 May 2017</time>
+                    </li>
+                </ul>
+                <p>Please let me know if this is ok, and if so which start date you would prefer.</p>
+                <p>You can find more information about <a target="_blank" href="http://example.com">important university dates</a> on our website.</p>
+            </section>
+            <section>
+                <h2>Subject of study</h2>
+                <p>At the Awesome Science Faculty, we have a pretty open-minded research facility — as long as the subjects fall somewhere in the realm of science and technology. You seem like an intelligent, dedicated researcher, and just the kind of person we'd like to have on our team. Saying that, of the ideas you submitted we were most intrigued by are as follows, in order of priority:</p>
+                <ol>
+                    <li>
+                        Turning H<sub>2</sub>O into wine, and the health benefits of Resveratrol (C<sub>14</sub>H<sub>12</sub>O<sub>3</sub>.)
+                    </li>
+                    <li>
+                        Measuring the effect on performance of funk bassplayers at temperatures exceeding 30°C (86°F), when the audience size exponentially increases (effect of 3 × 10<sup>3</sup> increasing to 3 × 10<sup>4</sup>.)
+                    </li>
+                    <li>
+                        <abbr title="Hyper Text Markup Language">HTML</abbr> and <abbr title="Cascading Style Sheets">CSS</abbr> constructs for representing musical scores.
+                    </li>
+                </ol>
+                <p>So please can you provide more information on each of these subjects, including how long you'd expect the research to take, required staff and other resources, and anything else you think we'd need to know? Thanks.</p>
+            </section>
+            <section>
+                <h2>Exotic dance moves</h2>
+                <p>Yes, you are right! As part of my post-doctorate work, I <em>did</em> study exotic tribal dances. To answer your question, my favourite dances are as follows, with definitions:</p>
+                <dl>
+                    <dt>
+                        Polynesian chicken dance
+                    </dt>
+                    <dd>
+                        A little known but <em>very</em> influential dance dating back as far as 300<abbr title="Before Christ">BC</abbr>, a whole village would dance around in a circle like chickens, to encourage their livestock to be "fruitful".
+                    </dd>
+                    <dt>
+                        Icelandic brownian shuffle
+                    </dt>
+                    <dd>
+                        Before the Icelanders developed fire as a means of getting warm, they used to practice this dance, which involved huddling close together in a circle on the floor, and shuffling their bodies around in imperceptibly tiny, very rapid movements. One of my fellow students used to say that he thought this dance inspired modern styles such as Twerking.
+                    </dd>
+                    <dt>
+                        Arctic robot dance
+                    </dt>
+                    <dd>
+                        An interesting example of historic misinformation, English explorers in the 1960s believed to have discovered a new dance style characterized by "robotic", stilted movements, being practiced by inhabitants of Northern Alaska and Canada. Later on however it was discovered that they were just moving like this because they were really cold.
+                    </dd>
+                </dl>
+            </section>
+            <section>
+                <p>For more of my research, see my exotic dance research page.</p>
+                <p>Yours sincerely,</p>
+                <p>Dr Eleanor Gaye</p>
+                <p>University of Awesome motto: <q cite="The memoirs of Bill S Preston, Esq">Be awesome to each other.</q><cite>--The memoirs of Bill S Preston, Esq</cite></p>
+            </section>
+        </article>
+    </main>
+    <footer>
+    </footer>
 </body>
 </html>

--- a/html/marking-up-a-letter.html
+++ b/html/marking-up-a-letter.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="" content="">
+    <meta name="author" content="JY">
     <title>Marking up a letter</title>
     <style>
         body {

--- a/html/marking-up-a-letter.html
+++ b/html/marking-up-a-letter.html
@@ -124,7 +124,7 @@
                 <p>For more of my research, see my exotic dance research page.</p>
                 <p>Yours sincerely,</p>
                 <p>Dr Eleanor Gaye</p>
-                <p>University of Awesome motto: <q cite="The memoirs of Bill S Preston, Esq">Be awesome to each other.</q><cite>--The memoirs of Bill S Preston, Esq</cite></p>
+                <p>University of Awesome motto: <q cite="TheMemoirsOfBillSPreston,Esq">Be awesome to each other.</q><cite>--The memoirs of Bill S Preston, Esq</cite></p>
             </section>
         </article>
     </main>


### PR DESCRIPTION
対応内容

- 申し送りのMDNサイトの課題の指定事項にmetaタグを使ってファイルの作成者名を実装する指示があったが、実装していなかったため、作成者名を明記するためのmetaタグの追加（以前の別のPRで属性が空のmetaタグは作成済みなので属性の追加をした）
- qタグのcite属性には空白が無効なのに空白を含む文字列が入っていたため、qタグのcite属性の値を空白を削除しキャメルケースに修正

確認事項
html/marking-up-a-letter.html- line:7 - ファイルの作成者を明記するためのmetaタグが実装されていること
html/marking-up-a-letter.html- line:127 - qタグのcite属性の値に空白が含まれていないこと、キャメルケースになっていること

申し送り

- marking-up-a-letter.htmlファイルは「MDNサイトの課題」として指定事項がある

- 「MDNサイトの課題」リンク
https://developer.mozilla.org/ko/docs/Learn/HTML/Introduction_to_HTML/Marking_up_a_letter

- W3C MVS上でWarningとして表示される問題については未対応