### PR TITLE
[fix]html.html audioセクションのsourceタグに無効な属性、preload削除

### DIFF
--- a/html/html.html
+++ b/html/html.html
@@ -953,8 +953,8 @@
                 <section>
                     <h3>audio</h3>
                     <article data-type="html-code">
-                        <audio controls>
-                            <source src="/assets/audio/512674__drumartist__smooth-686-cm.mp3" preload="auto" type="audio/mp3">
+                        <audio preload="auto" controls>
+                            <source src="/assets/audio/512674__drumartist__smooth-686-cm.mp3" type="audio/mp3">
                             <p>
                                 ブラウザによって実行できない場合がある
                                 <a href="https://freesound.org/people/Drumartist/sounds/512674/">その代わりの音源のリンク</a>


### PR DESCRIPTION
対応内容
audioセクションのaudioタグの中にあるsourceタグに無効な属性、preload属性が指定されていたため、そのpreload属性を削除。
元々preload属性をつけようとしていた箇所、audioタグにpreload属性を追加。

確認事項
html.html - line:956 - audioタグにpreload="auto"属性が設定されていること
html.html - line: 957 - sourceタグにpreload属性が削除されていること

申し送り
なし