### PR TITLE
Fix mozilla

### DIFF
--- a/src/html/mozilla_splash_page.html
+++ b/src/html/mozilla_splash_page.html
@@ -120,7 +120,7 @@
             <img 
             srcset="/assets/images/mozilla_splash_page_image/firefox_logo-only_RGB-120w.png 120w,
             /assets/images/mozilla_splash_page_image/firefox_logo-only_RGB-400w.png 400w" 
-            sizes="(max-width: 500px) 300px, 100%"
+            sizes="(max-width: 500px) 200px, 400px"
             src="/assets/images/mozilla_splash_page_image/firefox_logo-only_RGB-400w.png" 
             alt="">
         </a>
@@ -128,7 +128,7 @@
             <img 
             srcset="/assets/images/mozilla_splash_page_image/mozilla-dinosaur-head-120w.png 120w,
             /assets/images/mozilla_splash_page_image/mozilla-dinosaur-head-400w.png 400w" 
-            sizes="(max-width: 500px) 300px, 100%"
+            sizes="(max-width: 500px) 200px, 400px"
             src="/assets/images/mozilla_splash_page_image/mozilla-dinosaur-head-400w.png" 
             alt="">
         </a>
@@ -136,7 +136,7 @@
             <img 
             srcset="/assets/images/mozilla_splash_page_image/firefox-addons-120w.jpg 120w,
             /assets/images/mozilla_splash_page_image/firefox-addons-400w.jpg 400w" 
-            sizes="(max-width: 500px) 300px, 100%"
+            sizes="(max-width: 500px) 200px, 400px"
             src="/assets/images/mozilla_splash_page_image/firefox-addons-400w.jpg" 
             alt="">
         </a>

--- a/src/html/mozilla_splash_page.html
+++ b/src/html/mozilla_splash_page.html
@@ -62,6 +62,7 @@
         float: left;
         margin: 0 20px 20px 0;
         max-width: 100%;
+        border: none;
       }
 
       /* further info links */
@@ -104,7 +105,7 @@
 
     <main>
       <article>
-        <iframe width="400" height="315" src="https://www.youtube.com/embed/ojcNcvb1olg" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+        <iframe width="400" height="315" src="https://www.youtube.com/embed/ojcNcvb1olg" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
 
         <h2>Rocking the free web</h2>
 


### PR DESCRIPTION
**対応内容**

- [[fix]mozilla - iframeのframeborder属性を削除、CSS追加](https://github.com/rodmako/frontend/commit/95c6bf7c1fe44205b129e78d770d8c47d7779eda) 
iframeタグにframeborder属性が入っていてエラーが発生していたため、frameborder属性を削除しiframeのCSSの方にborder:noneを追加し解決

- [[fix]mozilla - 4つの画像全てに対し値の単位の修正](https://github.com/rodmako/frontend/commit/12102d8e2a7b76d718acf8e325fe23b1b39cdc65) 
imageタグで使われていたsizes属性の中で無効な単位（％）を使ってエラーが発生したため、無効な単位を有効な単位（px）に変更し解決

**確認事項**

- mozilla_splash_page.html - line:103 - iframeタグのframeborder属性が消えていること

- mozilla_splash_page.html - line:65 - iframeタグのCSSとしてborder: none; が追加されていること

- mozilla_splash_page.html - line:120~141 - ３つのimgタグのsizesタグに使われていた単位「％」がpxに変わっていること、値は確認事項外(svgファイルを利用しているimgタグを除いたimgタグ)


**申し送り**
なし