### PR TITLE
[fix]html_embedding カードにdata-target="jump"を追加

### DIFF
--- a/src/html/html_embedding.html
+++ b/src/html/html_embedding.html
@@ -98,7 +98,7 @@
                 </section>
             </article>
             <article class="card">
-                <h2>iframe, object</h2>
+                <h2 data-target="jump">iframe, object</h2>
                 <section>
                     <h3>iframe</h3>
                     <article data-type="html-code">
@@ -143,7 +143,7 @@
                 </section>
             </article>
             <article class="card">
-                <h2>Mozilla splash page</h2>
+                <h2 data-target="jump">Mozilla splash page</h2>
                 <section>
                     <h3>embedding課題</h3>
                     <a target="_blank" href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Mozilla_splash_page">MDN 課題</a>


### PR DESCRIPTION
対応内容

- 属性にdata-target="jump"が指定されていないカードに対しdata-target="jump"を追加

確認事項

- html_embedding.html - line:101 - h2タグに属性data-target="jump"が追加されていること

- html_embedding.html - line:146 - h2タグに属性data-target="jump"が追加されていること

- html_embedding.htmlをウェブで開き、ヘッダーの右側のボタン「list show」をクリック　→ 出てきたナビゲーションに「iframe, object」と「Mozilla splash page」リンクが追加されていることを確認　→ それらのリンクをクリックし、正しい場所に移動することを確認

申し送り
なし