### PR TITLE
[fix]mozilla - ページ全体のbackgroundが課題の指示と異なっていたため、修正

### DIFF
--- a/src/html/mozilla_splash_page.html
+++ b/src/html/mozilla_splash_page.html
@@ -10,7 +10,7 @@
 
       html {
         font-family: 'Open Sans', sans-serif;
-        background: url(pattern.png);
+        background: url('/assets/images/mozilla_splash_page_image/pattern.png');
       }
 
       body {


### PR DESCRIPTION
**対応内容**

- ページ全体のbackgroundが課題の指示と異なっていたためhtmlタグのCSSの方に課題の指示通りの画像pattern.pngを指定し解決

**確認事項**
mozilla_splash_page.htmlを開き、ページ全体の背景にpattern.png画像が表示されていること

**申し送り**
なし