### PR TITLE
[fix]html_embedding.html - iframeのframeborder属性でエラーが発生したため、frameborde…

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -137,6 +137,12 @@ main {
     border-radius: 3px;
 }
 
+iframe {
+    margin: 0 20px 20px 0;
+    max-width: 100%;
+    border: none;
+}
+
 video {
     width: 50%;
     height: auto;

--- a/src/html/html_embedding.html
+++ b/src/html/html_embedding.html
@@ -105,7 +105,7 @@
                     <h3>iframe</h3>
                     <article data-type="html-code">
                         <h4>iframeでYOUTUBE動画を利用</h4>
-                        <iframe width="560" height="315" src="https://www.youtube.com/embed/3sE2grIDYNw" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+                        <iframe width="560" height="315" src="https://www.youtube.com/embed/3sE2grIDYNw" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
                         <br>
                         <cite>
                             出所


### PR DESCRIPTION
…rを削除しiframeのCSS追加

**対応内容**
--
- MVS検証の結果frameborder属性を利用した場合エラーが発生したため、属性の削除。iframeタグのCSSの方でborder:noneを指定し同じ結果を表現・解決

**確認事項**
--
- html_embedding.htmlを開き、iframe, objectセクションのYOUTUBE動画のborderがないこと


**申し送り**
--
- なし
