### PR TITLE
[fix]html_table - colgroupセクションのタイトルが重複だったため削除

### DIFF
--- a/src/html/html_table.html
+++ b/src/html/html_table.html
@@ -68,7 +68,6 @@
     <main>
         <article class="container">
             <article class="card" data-target="jump">
-                <h2 data-target="jump-title">card</h2>
                 <h2 data-target="jump-title">colgroup</h2>
                 <section>
                     <h3>課題</h3>


### PR DESCRIPTION
**対応内容**
--
- カードのタイトル「colgroup」の上に「card」といった任意のタイトルが残っていて削除

**確認事項**
--
- タイトル「card」の文言が消えていること


**申し送り**
--
- なし
