### PR TITLE
Fix html element id and titles

### DIFF
--- a/src/html/html_element.html
+++ b/src/html/html_element.html
@@ -27,13 +27,13 @@
             <article class="card" data-target="jump">
                 <h2 data-target="jump-title">a</h2>
                 <section>
-                    <h3>download</h3>
+                    <h3>download="test.png" type="image/png"</h3>
                         <a href="/assets/images/mozilla_splash_page_image/firefox-addons-120w.jpg" type="image/png" download="test.png">
                             <img src="/assets/images/mozilla_splash_page_image/firefox-addons-120w.jpg" alt="">
                         </a>
                 </section>
                 <section>
-                    <h3>hreflang</h3>
+                    <h3>hreflang="ko"</h3>
                         <a href="https://developer.mozilla.org/ko/docs/Web/HTML/Element/a" hreflang="ko">
                             MDN-ko
                         </a>

--- a/src/html/html_element.html
+++ b/src/html/html_element.html
@@ -64,11 +64,11 @@
             <section data-type="html-code">
                 <h3>作ってみた</h3>
                 <map name="dinosaur-graphic">
-                    <area id="area1" shape="circle" coords="250,80,20"
+                    <area shape="circle" coords="250,80,20"
                     href="https://ja.wikipedia.org/wiki/%E7%9B%AE"
                     hreflang="ja"
                     target="_blank" alt="" title="eyes">
-                    <area id="area1" shape="circle" coords="300,170,40"
+                    <area shape="circle" coords="300,170,40"
                     href="https://ja.wikipedia.org/wiki/%E5%8F%A3"
                     hreflang="ja"
                     target="_blank" alt="" title="mouth">


### PR DESCRIPTION
**対応内容**
--
- areaタグの説明のセクションの中で使われているareaタグに不要なidが指定されていたため、そのidを削除
- aタグの説明のセクションの中で各セクションのタイトルの文言を修正

**確認事項**
--
- html_element.html - aタグの説明セクション - 各セクションのタイトルが修正されていること
- html_element.html - areaタグの説明セクション - 使われているareaタグにidが削除されていること2ヶ所


**申し送り**
--
- なし
