### PR TITLE
[fix]html_element areaタグ説明セクションの位置移動

### DIFF
--- a/src/html/html_element.html
+++ b/src/html/html_element.html
@@ -39,43 +39,43 @@
                         </a>
                 </section>
             </article>
-        </article>
-        <article class="card" data-target="jump">
-            <h2 data-target="jump-title">area</h2>
-            <section>
-                <ul>
-                    <li>
-                        areaタグはmapタグの中にいる必要がある
-                    </li>
-                    <li>
-                        shape="rect" coords="左上X,左上Y,右下X,右下Y"
-                    </li>
-                    <li>
-                        shape="circle" coords="X,Y,R"
-                    </li>
-                    <li>
-                        shape="poly" coords="x1,y1,x2,y2,x3,y3,x4,y4,x5,y5..."
-                    </li>
-                    <li>
-                        coordsの値の中には空白スペースが混ざってはいけない
-                    </li>
-                </ul>
-            </section>
-            <section data-type="html-code">
-                <h3>作ってみた</h3>
-                <map name="dinosaur-graphic">
-                    <area shape="circle" coords="250,80,20"
-                    href="https://ja.wikipedia.org/wiki/%E7%9B%AE"
-                    hreflang="ja"
-                    target="_blank" alt="" title="eyes">
-                    <area shape="circle" coords="300,170,40"
-                    href="https://ja.wikipedia.org/wiki/%E5%8F%A3"
-                    hreflang="ja"
-                    target="_blank" alt="" title="mouth">
-                </map>
-                <img usemap="#dinosaur-graphic" src="/assets/images/mozilla_splash_page_image/mozilla-dinosaur-head-400w.png" alt="dinosaur-graphic">
-                <pre class="code-pre" data-type="html-outer-text"></pre>
-            </section>
+            <article class="card" data-target="jump">
+                <h2 data-target="jump-title">area</h2>
+                <section>
+                    <ul>
+                        <li>
+                            areaタグはmapタグの中にいる必要がある
+                        </li>
+                        <li>
+                            shape="rect" coords="左上X,左上Y,右下X,右下Y"
+                        </li>
+                        <li>
+                            shape="circle" coords="X,Y,R"
+                        </li>
+                        <li>
+                            shape="poly" coords="x1,y1,x2,y2,x3,y3,x4,y4,x5,y5..."
+                        </li>
+                        <li>
+                            coordsの値の中には空白スペースが混ざってはいけない
+                        </li>
+                    </ul>
+                </section>
+                <section data-type="html-code">
+                    <h3>作ってみた</h3>
+                    <map name="dinosaur-graphic">
+                        <area shape="circle" coords="250,80,20"
+                        href="https://ja.wikipedia.org/wiki/%E7%9B%AE"
+                        hreflang="ja"
+                        target="_blank" alt="" title="eyes">
+                        <area shape="circle" coords="300,170,40"
+                        href="https://ja.wikipedia.org/wiki/%E5%8F%A3"
+                        hreflang="ja"
+                        target="_blank" alt="" title="mouth">
+                    </map>
+                    <img usemap="#dinosaur-graphic" src="/assets/images/mozilla_splash_page_image/mozilla-dinosaur-head-400w.png" alt="dinosaur-graphic">
+                    <pre class="code-pre" data-type="html-outer-text"></pre>
+                </section>
+            </article>
         </article>
     </main>
     <footer>


### PR DESCRIPTION
**対応内容**
--
- areaタグ説明セクションがメインとなるarticleタグの外に位置していたため、メインとなるarticleの中の方に移動

**確認事項**
--
- areaタグ説明セクションがクラスcontainerを持ったarticleの中に移動していること


**申し送り**
--
- なし
