### PR TITLE
[fix]html_element baseタグ説明セクションの内容を別のページに分離

### DIFF
--- a/src/html/html_element.html
+++ b/src/html/html_element.html
@@ -104,26 +104,7 @@
             <article class="card" data-target="jump">
                 <h2 data-target="jump-title">base</h2>
                 <section>
-                    <ul>
-                        <li>
-                            baseタグはページ内１個だけ使える
-                        </li>
-                        <li>
-                            baseはタグ名通り、ページ内で使われているURLのベースを決めるタグ
-                        </li>
-                        <li>
-                            URLを使っているすべての要素より前にある必要がある（baseタグ以降のものだけ適応される）
-                        </li>
-                        <li>
-                            色んな外部リンクを使っているページでは使えなさそう
-                        </li>
-                    </ul>
-                </section>
-                <section data-type="html-code">
-                    <base target="_blank" href="/">
-                    <a href="#こんな感じで動く">謎のリンク</a>
-                    <p>押してページのアドレスを見る</p>
-                    <pre class="code-pre" data-type="html-outer-text"></pre>
+                    <a href="./tag_base.html">tag_base.html</a>
                 </section>
             </article>
             <article class="card" data-target="jump">

--- a/src/html/tag_base.html
+++ b/src/html/tag_base.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>base tag</title>
+</head>
+<body>
+    <article class="card" data-target="jump">
+        <h2 data-target="jump-title">base</h2>
+        <section>
+            <ul>
+                <li>
+                    baseタグはページ内１個だけ使える
+                </li>
+                <li>
+                    baseはタグ名通り、ページ内で使われているURLのベースを決めるタグ
+                </li>
+                <li>
+                    URLを使っているすべての要素より前にある必要がある（baseタグ以降のものだけ適応される）
+                </li>
+                <li>
+                    色んな外部リンクを使っているページでは使えなさそう
+                </li>
+            </ul>
+        </section>
+        <section data-type="html-code">
+            <base target="_blank" href="/">
+            <a href="#こんな感じで動く">謎のリンク</a>
+            <p>押してページのアドレスを見る</p>
+            <pre class="code-pre" data-type="html-outer-text"></pre>
+        </section>
+    </article>
+</body>
+</html>


### PR DESCRIPTION


**対応内容**
--
- baseタグが使われていたためbaseタグ説明セクション以外の説明セクションも影響があったため、ページを分離

**確認事項**
--
- html_element.htmlを開き、baseタグ説明セクションのリンクをクリック → tag_base.htmlページが正常に表示されること


**申し送り**
--
- なし
